### PR TITLE
Improvements to Spectrogram

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,18 +45,42 @@ This is an early draft for a possible replacement of pytorch/audio. At this stag
 
 
 ## Overview
-### `STFT`/`stft`
-  ```python
-  class STFT(n_fft, hop_length=None, len_win=None, window=None, center=True, pad="reflect", normalized=False, onesided=True)
-  def stft(x, n_fft, hop_length=None, len_win=None, window=None, center=True, pad="reflect", normalized=False, onesided=True)
-  ```
-
-### `Melspectrogram`/`melspectrogram`
+### `STFT`
 ```python
-class Melspectrogram(n_mels, sr, f_max, f_min, *args, **kwargs)
-def melspectrogram(x, n_mels, sr, f_max, f_min, *args, **kwargs)
+class STFT(fft_len=2048, hop_len=None, frame_len=None, window=None, pad=0, pad_mode="reflect", **kwargs)
+def stft(signal, fft_len, hop_len, window, pad=0, pad_mode="reflect", **kwargs)
 ```
-These are wrappers for `STFT` to which `*args` and `**kwargs` are passed to.
+
+### `MelFilterbank`
+```python
+class MelFilterbank(num_bands=128, sample_rate=16000, min_freq=0.0, max_freq=None, num_bins=1025, htk=False)
+def create_mel_filter(num_bands, sample_rate, min_freq, max_freq, num_bins, to_hertz, from_hertz)
+```
+
+### `Spectrogram`
+```python
+def Spectrogram(fft_len=2048, hop_len=None, frame_len=None, window=None, pad=0, pad_mode="reflect", power=1., **kwargs)
+```
+Creates an `nn.Sequential`:
+```
+>>> Sequential(
+>>>  (0): STFT(fft_len=2048, hop_len=512, frame_len=2048)
+>>>  (1): ComplexNorm(power=1.0)
+)
+```
+
+### `Melspectrogram`
+```python
+def Melspectrogram(num_bands=128, sample_rate=16000, min_freq=0.0, max_freq=None, num_bins=None, htk=False, mel_filterbank=None, **kwargs)
+```
+Creates an `nn.Sequential`:
+```
+>>> Sequential(
+>>>  (0): STFT(fft_len=2048, hop_len=512, frame_len=2048)
+>>>  (1): ComplexNorm(power=2.0)
+>>>  (2): ApplyFilterbank()
+)
+```
 
 ### `AmplitudeToDb`/`amplitude_to_db`
 ```python

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,174 @@
+
+import unittest
+import torch
+import torch.nn as nn
+from torchaudio_contrib.layers import STFT, ComplexNorm, \
+    ApplyFilterbank, Spectrogram, Melspectrogram, MelFilterbank
+
+
+def _num_stft_bins(signal_len, fft_len, hop_len, pad):
+    return (signal_len + 2 * pad - fft_len + hop_len) // hop_len
+
+
+class Tester(unittest.TestCase):
+
+    def test_STFT(self):
+        """
+        STFT should handle mutlichannel signal correctly, as well as both cpu and cuda.
+
+        Padding (?)
+        """
+
+        def _test_mono_cpu():
+            signal = torch.randn(1, 100000)
+            fft_len, hop_len = 512, 256
+            layer = STFT(fft_len=fft_len, hop_len=hop_len)
+            spect = layer(signal)
+            assert spect.size(0) == 1
+            assert spect.size(1) == fft_len // 2 + 1
+            assert spect.size(2) == _num_stft_bins(
+                signal.size(-1), fft_len, hop_len, fft_len // 2)
+            assert spect.dim() == signal.dim() + 2
+
+        def _test_batch_multichannel_cuda():
+            signal = torch.randn(1, 2, 100000).cuda()
+            fft_len, hop_len = 512, 256
+            layer = STFT(fft_len=fft_len, hop_len=hop_len).cuda()
+            spect = layer(signal)
+
+            assert spect.size(1) == signal.size(1)
+            assert spect.is_cuda
+            assert spect.dim() == signal.dim() + 2
+
+        _test_mono_cpu()
+        _test_batch_multichannel_cuda()
+
+    def test_ComplexNorm(self):
+        """
+        ComplexNorm should normalize input correctly given a power of the magnitude.
+        """
+
+        def _test_powers(p):
+            stft = torch.randn(1, 257, 391, 2)
+            layer = ComplexNorm(power=p)
+            spect = layer(stft)
+            manual_spect = stft[0][0][0].pow(2).sum(-1).pow(1 / 2).pow(p)
+            assert stft.shape[1:3] == spect.shape[1:3]
+            assert manual_spect == spect[0][0][0]
+            assert stft.dim() - spect.dim() == 1
+
+        for p in [1, 2, 0.7]:
+            _test_powers(p)
+
+    def test_ApplyFilterbank(self):
+        """
+        ApplyFilterbank should apply correct transpose to input before multiplying it by the filter
+        """
+
+        def _test_mono_cuda():
+            new_len = 120
+            spect = torch.randn(1, 257, 391).cuda()
+            filterbank = torch.randn(spect.size(-2), new_len)
+
+            layer = ApplyFilterbank(filterbank).cuda()
+            spect2 = layer(spect)
+
+            assert spect.size(-1) == spect2.size(-1)
+            assert spect2.size(-2) == new_len
+            assert spect.dim() == spect2.dim()
+
+        def _test_multichannel_cpu():
+            new_len = 120
+            spect = torch.randn(1, 2, 257, 391)
+            filterbank = torch.randn(spect.size(-2), new_len)
+
+            layer = ApplyFilterbank(filterbank)
+            spect2 = layer(spect)
+
+            assert spect2.size(-2) == new_len
+            assert spect.dim() == spect2.dim()
+
+        _test_mono_cuda()
+        _test_multichannel_cpu()
+
+    def test_Spectrogram(self):
+        """
+        Spectrogram in an nn.Module should not store buffers in the state dict
+        """
+        def _create_toy_model(channels):
+            fft_len, hop_len = 512, 256
+            spect_layer = Spectrogram(
+                fft_len=fft_len, hop_len=hop_len, power=1)
+            conv_layer = nn.Conv2d(channels, 16, 3)
+            return nn.Sequential(spect_layer, conv_layer)
+
+        signal = torch.randn(1, 2, 100000)
+        toy_model = _create_toy_model(signal.size(1))
+
+        toy_model[1].weight.data.fill_(0)
+        sd = toy_model.state_dict()
+
+        toy_model2 = _create_toy_model(signal.size(1))
+        toy_model2.load_state_dict(sd)
+
+        assert len(sd.keys()) == 2
+        assert toy_model2[1].weight.data.sum() == 0
+
+    def test_Melspectrogram(self):
+        """
+        Melspectrogram in an nn.Module should not store buffers in the state dict.
+        Melspectrogram should work with a custom MelFilterbank
+        """
+        def _create_toy_model(channels):
+            num_bands, sample_rate, fft_len, hop_len = 96, 22050, 512, 256
+            mel_layer = Melspectrogram(
+                num_bands=num_bands,
+                sample_rate=sample_rate,
+                fft_len=fft_len,
+                hop_len=hop_len)
+            conv_layer = nn.Conv2d(channels, 16, 3)
+            return nn.Sequential(mel_layer, conv_layer)
+
+        class TestFilterbank(MelFilterbank):
+            """
+            Base class for providing a filterbank matrix.
+            """
+
+            def __init__(self, *args):
+                super(TestFilterbank, self).__init__(*args)
+
+            def get_filterbank(self):
+                return torch.randn(self.num_bins, self.num_bands)
+
+        def _test_mel_sd():
+
+            signal = torch.randn(1, 1, 100000)
+            toy_model = _create_toy_model(signal.size(1))
+
+            toy_model[1].weight.data.fill_(0)
+            sd = toy_model.state_dict()
+
+            toy_model2 = _create_toy_model(signal.size(1))
+            toy_model2.load_state_dict(sd)
+
+            assert len(sd.keys()) == 2
+            assert toy_model2[1].weight.data.sum() == 0
+
+        def _test_custom_fb():
+            num_bands, sample_rate, fft_len, hop_len = 128, 22050, 512, 256
+            signal = torch.randn(1, 1, 100000)
+            mel_layer = Melspectrogram(
+                num_bands=num_bands,
+                sample_rate=sample_rate,
+                fft_len=fft_len,
+                hop_len=hop_len,
+                mel_filterbank=TestFilterbank)
+            mel_spect = mel_layer(signal)
+            assert mel_spect.size(-2) == num_bands
+
+        _test_mel_sd()
+        _test_custom_fb()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -16,7 +16,7 @@ class Tester(unittest.TestCase):
         """
         STFT should handle mutlichannel signal correctly, as well as both cpu and cuda.
 
-        Padding (?)
+        Padding: Value in having padding outside of torch.stft?
         """
 
         def _test_mono_cpu():
@@ -57,7 +57,7 @@ class Tester(unittest.TestCase):
             assert manual_spect == spect[0][0][0]
             assert stft.dim() - spect.dim() == 1
 
-        for p in [1, 2, 0.7]:
+        for p in [1., 2., 0.7]:
             _test_powers(p)
 
     def test_ApplyFilterbank(self):

--- a/torchaudio_contrib/functional.py
+++ b/torchaudio_contrib/functional.py
@@ -5,10 +5,8 @@ import torch.nn.functional as F
 
 def stft_defaults(n_fft, hop_length, len_win, window):
     '''
-    Handle stft defaults (if torchaudio_contrib wants to handle 
-    them differently than torch.stft). Should function outisde 
-    torchaudio_contrib.stft since torchaudio_contrib.STFT will 
-    use it outisde of forward() (?).
+    Should function outisde torchaudio_contrib.stft since 
+    torchaudio_contrib.STFT will use it outisde of forward() (?).
     '''
     hop_length = n_fft // 4 if hop_length is None else hop_length
 
@@ -56,9 +54,8 @@ def _stft(x, n_fft, hop_length, window, pad, pad_mode, **kwargs):
 
     x = x.reshape(-1, time)
 
-    win_length = window.size(0)
     stft_out = torch.stft(x, n_fft, hop_length, window=window,
-                          win_length=win_length, **kwargs)
+                          win_length=window.size(0), **kwargs)
     stft_out = stft_out.reshape(out_shape)
 
     return stft_out
@@ -72,9 +69,8 @@ def stft(x, n_fft=2048, hop_length=None, len_win=None,
     """
     n_fft, hop_length, window = stft_defaults(
         n_fft, hop_length, len_win, window)
-    window = window.to(x.device)
     return _stft(x, n_fft=n_fft, hop_length=hop_length,
-                 window=window, pad=pad, pad_mode=pad_mode, **kwargs)
+                 window=window.to(x.device), pad=pad, pad_mode=pad_mode, **kwargs)
 
 
 def complex_norm(x, power=1.0):
@@ -148,7 +144,7 @@ def create_mel_filter(n_mels, sr, f_min, f_max, n_stft):
     return fb
 
 
-def melspectrogram(x, n_mels=128, sr=44100, f_min=0.0, f_max=None, n_stft=None, **kwargs):
+def melspectrogram(x, n_mels=128, sr=44100, f_min=0.0, f_max=None, **kwargs):
     """
     Compute the melspectrogram of a given signal. 
     See torchaudio_contrib.Melspectrogram for more details.

--- a/torchaudio_contrib/functional.py
+++ b/torchaudio_contrib/functional.py
@@ -3,166 +3,112 @@ import math
 import torch.nn.functional as F
 
 
-def stft_defaults(n_fft, hop_length, len_win, window):
-    """
-    Should function outisde torchaudio_contrib.stft since
-    torchaudio_contrib.STFT will use it outisde of forward() (?).
-    """
-    hop_length = n_fft // 4 if hop_length is None else hop_length
-
-    if window is None:
-        length = n_fft if len_win is None else len_win
-        window = torch.hann_window(length)
-        if not isinstance(window, torch.Tensor):
-            raise TypeError('window must be a of type torch.Tensor')
-
-    return n_fft, hop_length, window
-
-
-def _stft(x, n_fft, hop_length, window, pad, pad_mode, **kwargs):
+def stft(signal, fft_len, hop_len, window,
+         pad=0, pad_mode="reflect", **kwargs):
     """
     Wrap torch.stft allowing for multi-channel stft.
 
     Args:
-        x (Tensor): Tensor of audio of size (channel, signal)
-            or (batch, channel, signal).
-        n_fft (int): FFT window size.
-        hop_length (int): Number audio of frames between STFT columns.
-        len_win (int): Size of stft window.
+        signal (Tensor): Tensor of audio of size (channel, time)
+            or (batch, channel, time).
+        fft_len (int): FFT window size. Defaults to 2048.
+        hop_len (int): Number audio of frames between STFT columns.
         window (Tensor): 1-D tensor.
         pad (int): Amount of padding to apply to signal.
         pad_mode: padding method (see torch.nn.functional.pad).
         **kwargs: Other torch.stft parameters, see torch.stft for more details.
 
     Returns:
-        Tensor: (batch, channel, freq, hop, complex)
-            or (channel, freq, hop, complex)
+        Tensor: (batch, channel, num_bins, time, complex)
+            or (channel, num_bins, time, complex)
 
+    Example:
+        >>> signal = torch.randn(16, 2, 10000)
+        >>> # window_length <= fft_len
+        >>> window = torch.hamming_window(window_length=2048)
+        >>> x = stft(signal, 2048, 512, window)
+        >>> x.shape
+        torch.Size([16, 2, 1025, 20])
     """
 
     # (!) Only 3D, 4D, 5D padding with non-constant
     # padding are supported for now.
     if pad > 0:
-        x = F.pad(x, (pad, pad), pad_mode)
+        signal = F.pad(signal, (pad, pad), pad_mode)
 
-    if x.dim() == 3:
-        batch, channel, time = x.size()
-        out_shape = [batch, channel, n_fft // 2 + 1, -1, 2]
-    elif x.dim() == 2:
-        channel, time = x.size()
-        out_shape = [channel, n_fft // 2 + 1, -1, 2]
-    else:
-        raise ValueError('Input tensor dim() must be either 2 or 3.')
+    leading_dims = signal.shape[:-1]
 
-    x = x.reshape(-1, time)
+    signal = signal.reshape(-1, signal.size(-1))
 
-    stft_out = torch.stft(x, n_fft, hop_length, window=window,
-                          win_length=window.size(0), **kwargs)
-    stft_out = stft_out.reshape(out_shape)
+    spect = torch.stft(signal, fft_len, hop_len, window=window,
+                       win_length=window.size(0), **kwargs)
+    spect = spect.reshape(leading_dims + spect.shape[1:])
 
-    return stft_out
+    return spect
 
 
-def stft(x, n_fft=2048, hop_length=None, len_win=None,
-         window=None, pad=0, pad_mode="reflect", **kwargs):
+def complex_norm(signal, power=1.0):
     """
-    Wraps _stft setting default values and correct window device.
-    See torchaudio_contrib.STFT for more details.
+    Normalize complex signal.
     """
-    n_fft, hop_length, window = stft_defaults(
-        n_fft, hop_length, len_win, window)
-    return _stft(x, n_fft=n_fft, hop_length=hop_length,
-                 window=window.to(x.device), pad=pad,
-                 pad_mode=pad_mode, **kwargs)
+    if power == 1.:
+        return torch.norm(signal, 2, -1)
+    return torch.norm(signal, 2, -1).pow(power)
 
 
-def complex_norm(x, power=1.0):
-    """
-    Normalize complex tensor.
-    """
-    return x.pow(2).sum(-1).pow(power / 2.0)
-
-
-def spectrogram(x, n_fft=2048, hop_length=None, len_win=None,
-                window=None, pad=0, pad_mode="reflect", power=1., **kwargs):
-    """
-    Compute the spectrogram of a given signal.
-    See torchaudio_contrib.Spectrogram for more details.
-    """
-    return complex_norm(stft(x, n_fft, hop_length, len_win,
-                             window, pad, pad_mode, **kwargs), power=power)
-
-
-def _hertz_to_mel(f):
-    """
-    Converting frequency into mel values using HTK formula
-    """
-    return 2595. * torch.log10(torch.tensor(1.) + (f / 700.))
-
-
-def _mel_to_hertz(mel):
-    """
-    Converting mel values into frequency using HTK formula
-    """
-    return 700. * (10**(mel / 2595.) - 1.)
-
-
-def create_mel_filter(n_mels, sr, f_min, f_max, n_stft):
+def create_mel_filter(num_bands, sample_rate, min_freq,
+                      max_freq, num_bins, to_hertz, from_hertz):
     """
     Creates filter matrix to transform fft frequency bins
     into mel frequency bins.
-    Equivalent to librosa.filters.mel(sr, n_fft, htk=True, norm=None).
+    Equivalent to librosa.filters.mel(sample_rate, fft_len, htk=True, norm=None).
 
     Args:
-        n_mels (int): number of mel bins.
-        sr (int): sample rate of audio signal.
-        f_max (float, optional): maximum frequency.
-        f_min (float): minimum frequency.
-        n_stft (int, optional): number of filter banks from stft.
+        num_bands (int): number of mel bins.
+        sample_rate (int): sample rate of audio signal.
+        min_freq (float): minimum frequency.
+        max_freq (float): maximum frequency.
+        num_bins (int): number of filter banks from stft.
+        to_hertz (function): convert from mel freq to hertz
+        from_hertz (function): convert from hertz to mel freq
 
     Returns:
-        fb (Tensor): (n_stft, n_mels)
+        filterbank (Tensor): (num_bins, num_bands)
     """
     # Convert to find mel lower/upper bounds
-    f_max = f_max if f_max else sr // 2
-    n_stft = n_stft if n_stft else 1025
-
-    m_min = _hertz_to_mel(f_min)
-    m_max = _hertz_to_mel(f_max)
+    m_min = from_hertz(min_freq)
+    m_max = from_hertz(max_freq)
 
     # Compute stft frequency values
-    stft_freqs = torch.linspace(f_min, f_max, n_stft)
+    stft_freqs = torch.linspace(min_freq, max_freq, num_bins)
 
     # Find mel values, and convert them to frequency units
-    m_pts = torch.linspace(m_min, m_max, n_mels + 2)
-    f_pts = _mel_to_hertz(m_pts)
+    m_pts = torch.linspace(m_min, m_max, num_bands + 2)
+    f_pts = to_hertz(m_pts)
 
-    f_diff = f_pts[1:] - f_pts[:-1]  # (n_mels + 1)
-    # (n_stft, n_mels + 2)
+    f_diff = f_pts[1:] - f_pts[:-1]  # (num_bands + 1)
+    # (num_bins, num_bands + 2)
     slopes = f_pts.unsqueeze(0) - stft_freqs.unsqueeze(1)
 
-    down_slopes = (-1. * slopes[:, :-2]) / f_diff[:-1]  # (n_stft, n_mels)
-    up_slopes = slopes[:, 2:] / f_diff[1:]  # (n_stft, n_mels)
-    fb = torch.clamp(torch.min(down_slopes, up_slopes), min=0.)
+    down_slopes = (-1. * slopes[:, :-2]) / f_diff[:-1]  # (num_bins, num_bands)
+    up_slopes = slopes[:, 2:] / f_diff[1:]  # (num_bins, num_bands)
+    filterbank = torch.clamp(torch.min(down_slopes, up_slopes), min=0.)
 
-    return fb
+    return filterbank
 
 
-def melspectrogram(x, n_mels=128, sr=44100, f_min=0.0, f_max=None, **kwargs):
+def apply_filterbank(spect, filterbank):
     """
-    Compute the melspectrogram of a given signal.
-    See torchaudio_contrib.Melspectrogram for more details.
-    """
-    spec = spectrogram(x, **kwargs)
-    fb = create_mel_filter(
-        n_mels=n_mels,
-        sr=sr,
-        f_min=f_min,
-        f_max=f_max,
-        n_stft=spec.size(-2))
-    fb = fb.to(x.device)
+    Transform spectrogram given a filterbank matrix.
 
-    return torch.matmul(spec.transpose(-2, -1), fb).transpose(-2, -1)
+    Args:
+        spect (Tensor): (batch, channel, num_bins, time)
+        filterbank (Tensor): (num_bins, num_bands)
+
+    Returns:
+        (Tensor): (batch, channel, num_bands, time)
+    """
+    return torch.matmul(spect.transpose(-2, -1), filterbank).transpose(-2, -1)
 
 
 def angle(tensor):
@@ -172,61 +118,67 @@ def angle(tensor):
     return torch.atan2(tensor[..., 1], tensor[..., 0])
 
 
-def magphase(spec, power=1.):
+def magphase(spect, power=1.):
     """
     Separate a complex-valued spectrogram with shape (*,2)
     into its magnitude and phase.
     """
-    mag = spec.pow(2).sum(-1).pow(power / 2)
-    phase = angle(spec)
+    mag = complex_norm(spect, power)
+    phase = angle(spect)
     return mag, phase
 
 
-def phase_vocoder(spec, rate, phi_advance):
+def phase_vocoder(spect, rate, phi_advance):
     """
     Phase vocoder. Given a STFT tensor, speed up in time
     without modifying pitch by a factor of `rate`.
 
+    Args:
+        spect (Tensor): (batch, channel, num_bins, time, 2)
+        rate (float): Speed-up factor
+        phi_advance (Tensor): Expected phase advance in each bin. (num_bins, 1)
 
-    Input Tensor shape -> (batch, channel, freq, time, 2)
-    Output Tensor shape -> (batch, channel, freq, time//rate+1, 2)
+    Returns:
+      (Tensor): (batch, channel, num_bins, new_bins, 2) with new_bins = num_bins//rate+1
     """
 
-    time_steps = torch.arange(0, spec.size(
-        3), rate, device=spec.device)  # (new_time)
+    time_steps = torch.arange(0, spect.size(
+        3), rate, device=spect.device)  # (new_bins,)
 
-    alphas = (time_steps % 1)  # (new_time)
+    alphas = (time_steps % 1)  # (new_bins,)
 
-    phase_0 = angle(spec[:, :, :, :1])
+    phase_0 = angle(spect[:, :, :, :1])
 
     # Time Padding
     pad_shape = [0, 0] + [0, 2] + [0] * 6
-    spec = torch.nn.functional.pad(spec, pad_shape)
+    spect = torch.nn.functional.pad(spect, pad_shape)
 
-    spec_0 = spec[:, :, :, time_steps.long()]  # (new_time, freq, 2)
-    spec_1 = spec[:, :, :, (time_steps + 1).long()]  # (new_time, freq, 2)
+    spec_0 = spect[:, :, :, time_steps.long()]  # (new_bins, num_bins, 2)
+    spec_1 = spect[:, :, :, (time_steps + 1).long()]  # (new_bins, num_bins, 2)
 
-    spec_0_angle = angle(spec_0)  # (new_time, freq)
-    spec_1_angle = angle(spec_1)  # (new_time, freq)
+    spec_0_angle = angle(spec_0)  # (new_bins, num_bins)
+    spec_1_angle = angle(spec_1)  # (new_bins, num_bins)
 
-    spec_0_norm = torch.norm(spec_0, dim=-1)  # (new_time, freq)
-    spec_1_norm = torch.norm(spec_1, dim=-1)  # (new_time, freq)
+    spec_0_norm = torch.norm(spec_0, dim=-1)  # (new_bins, num_bins)
+    spec_1_norm = torch.norm(spec_1, dim=-1)  # (new_bins, num_bins)
 
-    spec_phase = spec_1_angle - spec_0_angle - phi_advance  # (new_time, freq)
+    spec_phase = spec_1_angle - spec_0_angle - \
+        phi_advance  # (new_bins, num_bins)
     spec_phase = spec_phase - 2 * math.pi * \
-        torch.round(spec_phase / (2 * math.pi))  # (new_time, freq)
+        torch.round(spec_phase / (2 * math.pi))  # (new_bins, num_bins)
 
     # Compute Phase Accum
-    phase = spec_phase + phi_advance  # (new_time, freq)
+    phase = spec_phase + phi_advance  # (new_bins, num_bins)
 
     phase = torch.cat([phase_0, phase[:, :, :, :-1]], dim=-1)
 
-    phase_acc = torch.cumsum(phase, -1)  # (new_time, freq)
+    phase_acc = torch.cumsum(phase, -1)  # (new_bins, num_bins)
 
-    mag = alphas * spec_1_norm + (1 - alphas) * spec_0_norm  # (new_time, freq)
+    mag = alphas * spec_1_norm + (1 - alphas) * \
+        spec_0_norm  # (time//rate+1, num_bins)
 
-    spec_stretch_real = mag * torch.cos(phase_acc)  # (new_time, freq)
-    spec_stretch_imag = mag * torch.sin(phase_acc)  # (new_time, freq)
+    spec_stretch_real = mag * torch.cos(phase_acc)  # (new_bins, num_bins)
+    spec_stretch_imag = mag * torch.sin(phase_acc)  # (new_bins, num_bins)
 
     spec_stretch = torch.stack([spec_stretch_real, spec_stretch_imag], dim=-1)
 

--- a/torchaudio_contrib/layers.py
+++ b/torchaudio_contrib/layers.py
@@ -7,12 +7,16 @@ from .functional import stft_defaults, _stft, complex_norm, create_mel_filter, p
 
 class _ModuleNoStateBuffers(nn.Module):
     """
-    Extension of nn.Module
+    Extension of nn.Module that removes buffers
+    from state_dict.
+
+    Args:
+        buffers (dict): mapping of names and tensors to be registered.
     """
 
-    def __init__(self, buffs):
+    def __init__(self, buffers):
         super(_ModuleNoStateBuffers, self).__init__()
-        for k, v in buffs.items():
+        for k, v in buffers.items():
             self.register_buffer(k, v)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
@@ -76,7 +80,7 @@ class STFT(_ModuleNoStateBuffers):
 
 class ComplexNorm(nn.Module):
     """
-    Wrap complex_norm in a nn.Module.
+    Wrap complex_norm in an nn.Module.
     """
 
     def __init__(self, power=1.0):
@@ -102,7 +106,7 @@ class Filterbank(_ModuleNoStateBuffers):
         Returns:
             fb_out (Tensor): freq -> fb.size(0)
         """
-        return torch.matmul(x.transpose(2, 3), self.fb).transpose(2, 3)
+        return torch.matmul(x.transpose(-2, -1), self.fb).transpose(-2, -1)
 
 
 class MelFilterbank(Filterbank):

--- a/torchaudio_contrib/layers.py
+++ b/torchaudio_contrib/layers.py
@@ -2,7 +2,8 @@ import torch
 import math
 import torch.nn as nn
 
-from .functional import stft_defaults, _stft, complex_norm, create_mel_filter, phase_vocoder
+from .functional import stft_defaults, _stft, complex_norm, \
+    create_mel_filter, phase_vocoder
 
 
 class _ModuleNoStateBuffers(nn.Module):
@@ -23,7 +24,7 @@ class _ModuleNoStateBuffers(nn.Module):
         ret = super(_ModuleNoStateBuffers, self).state_dict(
             destination, prefix, keep_vars)
         for k in self._buffers.keys():
-            del ret[prefix+k]
+            del ret[prefix + k]
         return ret
 
 
@@ -35,11 +36,14 @@ class STFT(_ModuleNoStateBuffers):
     Args:
 
         n_fft (int): FFT window size. Defaults to 2048.
-        hop_length (int): Number audio of frames between stft columns. Defaults to n_fft // 4.
+        hop_length (int): Number audio of frames between stft columns.
+            Defaults to n_fft // 4.
         len_win (int): Size of stft window. Defaults to n_fft.
-        window (Tensor): 1-D tensor. Defaults to Hanning Window of size len_win.
+        window (Tensor): 1-D tensor. Defaults to Hanning Window
+            of size len_win.
         pad (int): Amount of padding to apply to signal. Defaults to 0.
-        pad_mode: padding method (see torch.nn.functional.pad). Defaults to "reflect".
+        pad_mode: padding method (see torch.nn.functional.pad).
+            Defaults to "reflect".
         **kwargs: Other torch.stft parameters, see torch.stft for more details.
 
     """
@@ -63,12 +67,19 @@ class STFT(_ModuleNoStateBuffers):
             x (Tensor): (channel, signal) or (batch, channel, signal).
 
         Returns:
-            stft_out (Tensor): (channel, time, freq, complex) or (batch, channel, time, freq, complex).
+            stft_out (Tensor): (channel, time, freq, complex)
+                or (batch, channel, time, freq, complex).
         """
 
         # use registered window so have to use _stft
-        stft_out = _stft(x, self.n_fft, self.hop_length, window=self.window, pad=self.pad,
-                         pad_mode=self.pad_mode, **self.kwargs)
+        stft_out = _stft(
+            x,
+            self.n_fft,
+            self.hop_length,
+            window=self.window,
+            pad=self.pad,
+            pad_mode=self.pad_mode,
+            **self.kwargs)
 
         return stft_out
 
@@ -92,6 +103,7 @@ class ComplexNorm(nn.Module):
 
 
 class Filterbank(_ModuleNoStateBuffers):
+
     def __init__(self):
         super(Filterbank, self).__init__({'fb': self._build_fb()})
 
@@ -104,7 +116,7 @@ class Filterbank(_ModuleNoStateBuffers):
             x (Tensor): (channel, time, freq) or (batch, channel, time, freq).
 
         Returns:
-            fb_out (Tensor): freq -> fb.size(0)
+            ret (Tensor): freq -> fb.size(0)
         """
         return torch.matmul(x.transpose(-2, -1), self.fb).transpose(-2, -1)
 
@@ -119,10 +131,12 @@ class MelFilterbank(Filterbank):
         sr (int): sample rate of audio signal. Defaults to 44100.
         f_max (float, optional): maximum frequency. Defaults to sr // 2.
         f_min (float): minimum frequency. Defaults to 0.
-        n_stft (int, optional): number of filter banks from stft. Defaults to 2048//2 + 1.
+        n_stft (int, optional): number of filter banks from stft.
+            Defaults to 2048//2 + 1.
     """
 
-    def __init__(self, n_mels=128, sr=44100, f_min=0.0, f_max=None, n_stft=None):
+    def __init__(self, n_mels=128, sr=44100,
+                 f_min=0.0, f_max=None, n_stft=None):
 
         self.n_stft = n_stft
         self.n_mels = n_mels
@@ -153,8 +167,10 @@ class StretchSpecTime(_ModuleNoStateBuffers):
     Args:
 
         rate (float): rate to speed up or slow down by.
-        hop_length (int): Number audio of frames between STFT columns. Defaults to 512.
-        n_stft (int, optional): number of filter banks from stft. Defaults to 1025.
+        hop_length (int): Number audio of frames between STFT columns.
+            Defaults to 512.
+        n_stft (int, optional): number of filter banks from stft.
+            Defaults to 1025.
     """
 
     def __init__(self, rate, hop_length=512, n_stft=1025):
@@ -182,19 +198,31 @@ def Spectrogram(n_fft=2048, hop_length=None, len_win=None,
     Args:
 
         n_fft (int): FFT window size. Defaults to 2048.
-        hop_length (int): Number audio of frames between STFT columns. Defaults to n_fft // 4.
+        hop_length (int): Number audio of frames between STFT columns.
+            Defaults to n_fft // 4.
         len_win (int): Size of stft window. Defaults to n_fft.
-        window (Tensor): 1-D tensor. Defaults to Hanning Window of size len_win.
+        window (Tensor): 1-D tensor.
+            Defaults to Hanning Window of size len_win.
         pad (int): Amount of padding to apply to signal. Defaults to 0.
-        pad_mode: padding method (see torch.nn.functional.pad). Defaults to "reflect".
+        pad_mode: padding method (see torch.nn.functional.pad).
+            Defaults to "reflect".
         power (float): What power to normalize to. Defaults to 1.
         **kwargs: Other torch.stft parameters, see torch.stft for more details.
     """
-    return nn.Sequential(STFT(n_fft, hop_length, len_win,
-                              window, pad, pad_mode, **kwargs), ComplexNorm(power))
+    return nn.Sequential(
+        STFT(
+            n_fft,
+            hop_length,
+            len_win,
+            window,
+            pad,
+            pad_mode,
+            **kwargs),
+        ComplexNorm(power))
 
 
-def Melspectrogram(n_mels=128, sr=44100, f_min=0.0, f_max=None, n_stft=None, **kwargs):
+def Melspectrogram(n_mels=128, sr=44100, f_min=0.0,
+                   f_max=None, n_stft=None, **kwargs):
     """
     Get melspectrogram module.
 
@@ -203,10 +231,11 @@ def Melspectrogram(n_mels=128, sr=44100, f_min=0.0, f_max=None, n_stft=None, **k
         sr (int): sample rate of audio signal. Defaults to 44100.
         f_max (float, optional): maximum frequency. Defaults to sr // 2.
         f_min (float): minimum frequency. Defaults to 0.
-        n_stft (int, optional): number of filter banks from stft. Defaults to n_fft//2 + 1 if 'n_fft' in kwargs else 1025.
+        n_stft (int, optional): number of filter banks from stft.
+            Defaults to n_fft//2 + 1 if 'n_fft' in kwargs else 1025.
         **kwargs: torchaudio_contrib.Spectrogram parameters.
     """
     n_fft = kwargs.get('n_fft', None)
-    n_stft = n_fft//2 + 1 if n_fft else n_stft
+    n_stft = n_fft // 2 + 1 if n_fft else n_stft
     return nn.Sequential(*Spectrogram(**kwargs),
                          MelFilterbank(n_mels, sr, f_min, f_max, n_stft))

--- a/torchaudio_contrib/layers.py
+++ b/torchaudio_contrib/layers.py
@@ -80,7 +80,7 @@ class STFT(_ModuleNoStateBuffers):
 
 class ComplexNorm(nn.Module):
     """
-    Wrap complex_norm in an nn.Module.
+    Wrap torchaudio_contrib.complex_norm in an nn.Module.
     """
 
     def __init__(self, power=1.0):
@@ -187,7 +187,7 @@ def Spectrogram(n_fft=2048, hop_length=None, len_win=None,
         window (Tensor): 1-D tensor. Defaults to Hanning Window of size len_win.
         pad (int): Amount of padding to apply to signal. Defaults to 0.
         pad_mode: padding method (see torch.nn.functional.pad). Defaults to "reflect".
-        power (float): What power to normalize to.
+        power (float): What power to normalize to. Defaults to 1.
         **kwargs: Other torch.stft parameters, see torch.stft for more details.
     """
     return nn.Sequential(STFT(n_fft, hop_length, len_win,
@@ -199,15 +199,14 @@ def Melspectrogram(n_mels=128, sr=44100, f_min=0.0, f_max=None, n_stft=None, **k
     Get melspectrogram module.
 
     Args:
-        n_mels (int): number of mel bins.
-        sr (int): sample rate of audio signal.
+        n_mels (int): number of mel bins. Defaults to 128.
+        sr (int): sample rate of audio signal. Defaults to 44100.
         f_max (float, optional): maximum frequency. Defaults to sr // 2.
         f_min (float): minimum frequency. Defaults to 0.
         n_stft (int, optional): number of filter banks from stft. Defaults to n_fft//2 + 1 if 'n_fft' in kwargs else 1025.
         **kwargs: torchaudio_contrib.Spectrogram parameters.
     """
     n_fft = kwargs.get('n_fft', None)
-    if n_fft:
-        n_stft = n_fft//2 + 1
+    n_stft = n_fft//2 + 1 if n_fft else n_stft
     return nn.Sequential(*Spectrogram(**kwargs),
                          MelFilterbank(n_mels, sr, f_min, f_max, n_stft))


### PR DESCRIPTION
Addressing issues [19](https://github.com/keunwoochoi/torchaudio-contrib/issues/19), [20](https://github.com/keunwoochoi/torchaudio-contrib/issues/20), [22](https://github.com/keunwoochoi/torchaudio-contrib/issues/22).

- Favoring composition over inheritance. e.g.:
`Spectrogram()`
```python
...
return nn.Sequential(STFT(n_fft, hop_length, len_win,
                              window, pad, pad_mode, **kwargs), ComplexNorm(power))
```
while the functional looks like:
```python
...
return complex_norm(stft(x, n_fft, hop_length, len_win,
                             window, pad, pad_mode, **kwargs), power=power)
```
- Using buffers instead of `nn.Parameter(requires_grad=False)` and not including them in the `state_dict`.
- More consistency with the args

