### PR TITLE
Switch test execution to pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ python:
 install:
   - pip install -e .[tests]
 script:
-  - python -m unittest discover -s tests
+  - python -m pytest

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,6 @@ setup(name='torchaudio_contrib',
       author_email='gnuchoi@gmail.com',
       license='MIT',
       install_requires=['torch'],
-      extras_require={'tests': ['librosa']},
+      extras_require={'tests': ['pytest', 'librosa']},
       packages=['torchaudio_contrib'],
       zip_safe=False)


### PR DESCRIPTION
As proposed in #39 this switches the testing framework to use pytest to run the tests.

I also started to rework `tests/test_layers.py` to provide a show case how to use pytest to simplify the actual tests, but this requires a little bit more time and should be independent of this pull request.